### PR TITLE
feat: Add @formidable.Label("foo") annotation for custom labels

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -146,6 +146,7 @@ describe('Form interactions', () => {
       cy.get('.value').should('have.text', 'Cat(Tiger,4)') // test default value
       cy.get('select').select('Dog')
       cy.get('.value').should('have.text', 'Dog(,true)') // test default value
+      cy.get('table > tr:nth-child(2)').should('have.text', 'Hungry?') // test Label("Hungry?")
     })
   })
 
@@ -164,10 +165,10 @@ describe('Form interactions', () => {
 
   it('BinaryTree (recursive sealed trait)', () => {
       cy.get('.BinaryTree').within(($form) => {
-      cy.get('select').select('Branch')
+      cy.get('select').select('Branch Node')
       cy.get('.value').should('have.text', 'Branch(Leaf(0),Leaf(0))')
-      cy.contains('tr', 'right:').contains('select', 'Leaf').select('Branch')
-      cy.contains('tr', 'left:').contains('select', 'Leaf').select('Branch')
+      cy.contains('tr', 'right:').contains('select', 'Leaf Node').select('Branch Node')
+      cy.contains('tr', 'left:').contains('select', 'Leaf Node').select('Branch Node')
       cy.get('.value').should('have.text', 'Branch(Branch(Leaf(0),Leaf(0)),Branch(Leaf(0),Leaf(0)))')
       cy.get('input[type="text"]').each((elem,index) => cy.wrap(elem).clear().type(index))
       cy.get('.value').should('have.text', 'Branch(Branch(Leaf(0),Leaf(1)),Branch(Leaf(2),Leaf(3)))')

--- a/demo/src/main/scala/Main.scala
+++ b/demo/src/main/scala/Main.scala
@@ -21,7 +21,9 @@ case class Tree(value: Int = 2, children: Seq[Tree])
 sealed trait BinaryTree
 object BinaryTree {
   @formidable.Default
+  @formidable.Label("Leaf Node")
   case class Leaf(value: Int)                            extends BinaryTree
+  @formidable.Label("Branch Node")
   case class Branch(left: BinaryTree, right: BinaryTree) extends BinaryTree
 }
 

--- a/demo/src/main/scala/Main.scala
+++ b/demo/src/main/scala/Main.scala
@@ -11,7 +11,7 @@ case class Person(name: String, age: Int = 5)
 
 sealed trait Pet
 object Pet {
-  case class Dog(name: String, hungry: Boolean = true) extends Pet
+  case class Dog(name: String, @formidable.Label("Hungry?") hungry: Boolean = true) extends Pet
   @formidable.Default
   case class Cat(name: String, legs: Int = 4) extends Pet
 }

--- a/demo/src/main/scala/Main.scala
+++ b/demo/src/main/scala/Main.scala
@@ -22,7 +22,7 @@ sealed trait BinaryTree
 object BinaryTree {
   @formidable.Default
   @formidable.Label("Leaf Node")
-  case class Leaf(value: Int)                            extends BinaryTree
+  case class Leaf(value: Int) extends BinaryTree
   @formidable.Label("Branch Node")
   case class Branch(left: BinaryTree, right: BinaryTree) extends BinaryTree
 }

--- a/formidable/src/main/scala-2/Form-Scala2.scala
+++ b/formidable/src/main/scala-2/Form-Scala2.scala
@@ -42,11 +42,14 @@ trait FormDerivation {
       val selectedSubtype: Var[Subtype[Form, T]] =
         selectedValue.imap[Subtype[Form, T]](subType => subType.typeclass.default)(value => ctx.split(value)(identity))
 
+      def labelForSubtype(subtype: Subtype[Form, _]): String =
+        subtype.annotations.collectFirst { case Label(l) => l }.getOrElse(subtype.typeName.short)
+
       config.unionSubform(
         config.selectInput[Subtype[Form, T]](
           options = ctx.subtypes,
           selectedValue = selectedSubtype,
-          show = subtype => subtype.typeName.short,
+          show = labelForSubtype,
         ),
         subForm = selectedValue.map { value =>
           ctx.split(value) { sub =>

--- a/formidable/src/main/scala-2/Form-Scala2.scala
+++ b/formidable/src/main/scala-2/Form-Scala2.scala
@@ -25,7 +25,8 @@ trait FormDerivation {
             .map { case (param, subState) =>
               val subForm = ((s: Var[param.PType], c) => param.typeclass.render(s, c))
                 .asInstanceOf[(Var[Any], FormConfig) => VModifier]
-              param.label -> subForm(subState, config)
+              val label = param.annotations.collectFirst { case Label(l) => l }.getOrElse(param.label + ":")
+              label -> subForm(subState, config)
             }
         )
       }: VModifier

--- a/formidable/src/main/scala-3/Form-Scala3.scala
+++ b/formidable/src/main/scala-3/Form-Scala3.scala
@@ -22,7 +22,8 @@ trait FormDerivation extends AutoDerivation[Form] {
             .zip(subStates)
             .map { case (param, subState) =>
               val subForm = (param.typeclass.render _).asInstanceOf[(Var[Any], FormConfig) => VModifier]
-              param.label -> subForm(subState, config)
+              val label = param.annotations.collectFirst { case Label(l) => l }.getOrElse(param.label + ":")
+              label -> subForm(subState, config)
             }
         )
       }: VModifier

--- a/formidable/src/main/scala-3/Form-Scala3.scala
+++ b/formidable/src/main/scala-3/Form-Scala3.scala
@@ -41,11 +41,14 @@ trait FormDerivation extends AutoDerivation[Form] {
           ctx.choose(value)(_.subtype)
         )
 
+      def labelForSubtype[Type, SType](subtype: SealedTrait.Subtype[Form, Type, SType]): String =
+        subtype.annotations.collectFirst { case Label(l) => l }.getOrElse(subtype.typeInfo.short)
+
       config.unionSubform(
         config.selectInput[SealedTrait.Subtype[Form, T, _]](
           options = ctx.subtypes,
           selectedValue = selectedSubtype,
-          show = subtype => subtype.typeInfo.short,
+          show = labelForSubtype,
         ),
         selectedValue.map { value =>
           ctx.choose(value) { sub =>

--- a/formidable/src/main/scala-3/Form-Scala3.scala
+++ b/formidable/src/main/scala-3/Form-Scala3.scala
@@ -22,7 +22,7 @@ trait FormDerivation extends AutoDerivation[Form] {
             .zip(subStates)
             .map { case (param, subState) =>
               val subForm = (param.typeclass.render _).asInstanceOf[(Var[Any], FormConfig) => VModifier]
-              val label = param.annotations.collectFirst { case Label(l) => l }.getOrElse(param.label + ":")
+              val label   = param.annotations.collectFirst { case Label(l) => l }.getOrElse(param.label + ":")
               label -> subForm(subState, config)
             }
         )

--- a/formidable/src/main/scala/Form.scala
+++ b/formidable/src/main/scala/Form.scala
@@ -6,6 +6,9 @@ import outwatch._
 // used to mark default cases of sealed traits
 case class Default() extends scala.annotation.StaticAnnotation
 
+// used to customize labels for fields and types
+case class Label(label: String) extends scala.annotation.StaticAnnotation
+
 trait Form[T] {
   def default: T
   def render(

--- a/formidable/src/main/scala/FormConfig.scala
+++ b/formidable/src/main/scala/FormConfig.scala
@@ -15,7 +15,7 @@ trait FormConfig {
     div(display.flex, VModifier.style("gap") := "0.5rem", subForms)
   def labeledFormGroup(subForms: Seq[(String, VModifier)]): VModifier =
     table(
-      subForms.map { case (label, subForm) => tr(td(b(label, ": "), verticalAlign := "top"), td(subForm)) }
+      subForms.map { case (label, subForm) => tr(td(b(label), verticalAlign := "top"), td(subForm)) }
     )
 
   def formSequence(subForms: Seq[VModifier], addButton: VModifier): VModifier =


### PR DESCRIPTION
This allows code like:

```scala
sealed trait Foo

@formidable.Label("Foo-Bar")
case class Bar(@formidable.Label("Foo-Bar-param") param: Int)
```

Which will replace the default labels, which are generated from the class name or parameter name, with the given custom strings.

Also added some usages to the examples.

Note: I switched from scala 2 to 3 by changing the version in `build.sbt`, but I had to clean and recompile to see the changes working in scala 3.

Edit: Screenshots:

Custom label "Hungry?" for a parameter:
![image](https://user-images.githubusercontent.com/1130337/208256844-7b19483f-43e8-4b37-82b8-7d679a5ce254.png)

Custom labels "Leaf Node" and "Branch Node" for case classes:
![image](https://user-images.githubusercontent.com/1130337/208256920-527ef685-a4f4-4adf-9b5d-de4161cec21f.png)
